### PR TITLE
Shared config for mp4 automation and clean-up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,19 @@ FROM linuxserver/sonarr
 
 RUN \
   apt-get update && \
-  apt-get install -y ffmpeg git python-pip openssl python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev zlib1g-dev && \
+  apt-get install -y \
+  ffmpeg \
+  git \
+  python-pip \
+  openssl \
+  python-dev \
+  libffi-dev \
+  libssl-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  zlib1g-dev
+
+RUN \
   pip install --upgrade pip && \
   pip install requests && \
   pip install requests[security] && \
@@ -13,10 +25,14 @@ RUN \
   pip install stevedore==1.19.1 && \
   pip install python-dateutil && \
   pip install qtfaststart && \
-  git clone git://github.com/mdhiggins/sickbeard_mp4_automator.git /sickbeard_mp4_automator/ && \ 
+  git clone git://github.com/mdhiggins/sickbeard_mp4_automator.git /sickbeard_mp4_automator/ && \
   touch /sickbeard_mp4_automator/info.log && \
   chmod a+rwx -R /sickbeard_mp4_automator && \
+  ln -s /downloads /data && \
+  ln -s /config_mp4_automator/autoProcess.ini /sickbeard_mp4_automator/autoProcess.ini && \
   rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \
 	/var/tmp/*
+
+VOLUME config_mp4_automator

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# docker-sonarr-mp4-automator
+# aront/sonarr
 A docker container based on linuxserver/sonarr with mp4 automation baked in
+
+## Usage
+````
+docker create \
+    --name sonarr \
+    --restart unless-stopped \
+    -p 8989:8989 \
+    -e PUID=1001 -e PGID=1001 \
+    -e TZ="America/Chicago"  \
+    -v <path to data>:/config \
+    -v <path to data>/mp4_automator:/config_mp4_automator \
+    -v <path to data>:/movies \
+    -v <path to data>:/downloads \
+    aront/sonarr
+    
+mkdir <path to data>/mp4_automator && \
+wget https://raw.githubusercontent.com/mdhiggins/sickbeard_mp4_automator/master/autoProcess.ini.sample -O <path to data>/mp4_automator/autoProcess.ini
+````
+
+## Parameters
+See [https://hub.docker.com/r/linuxserver/sonarr/](https://hub.docker.com/r/linuxserver/sonarr/) for details.
+
+## mkdir
+Makes a symlink from sickbeard_mp4_automator to a config directory that is a volume for the container. If the host has a config file (autoProcess.ini) in the mounted volume, then sickbeard_mp4_automator will be able to use that. This is useful if you are running multiple containers but want to share the mp4 automation configuration between them. It also has the benefit of being able to modify the config from the host OS.


### PR DESCRIPTION
Makes a symlink from sickbeard_mp4_automator to a config directory that is a volume for the container. If the host has a config file (autoProcess.ini) in the mounted volume, then sickbeard_mp4_automator will be able to use that. This is useful if you are running multiple containers but want to share the mp4 automation configuration between them. It also has the benefit of being able to modify the config from the host OS.

If you're starting from scratch, this will create the path and download a sample config to that location:
mkdir <path to data>/mp4_automator && \
wget https://raw.githubusercontent.com/mdhiggins/sickbeard_mp4_automator/master/autoProcess.ini.sample -O <path to data>/mp4_automator/autoProcess.ini